### PR TITLE
Fix import and define IS_CI

### DIFF
--- a/sareth.py
+++ b/sareth.py
@@ -2,6 +2,9 @@ import os
 import json
 import datetime
 
+# Detect if running in a Continuous Integration environment
+IS_CI = os.environ.get("CI") == "true"
+
 # Placeholder engine runner
 
 def run_sareth_engine(prompt: str) -> str:


### PR DESCRIPTION
## Summary
- add missing `IS_CI` constant in `sareth.py`
- ensure environment variable detection works for CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eba2a49a88328ab8f8330d4eaea1e