### PR TITLE
Add IBM Cloud auth step and split k8s manifests

### DIFF
--- a/.github/workflows/iks_prod_deploy_pipeline.yml
+++ b/.github/workflows/iks_prod_deploy_pipeline.yml
@@ -33,6 +33,12 @@ jobs:
           ibmcloud plugin install -f kubernetes-service
           ibmcloud plugin install -f container-registry
 
+      - name: 🔑 Authenticate with IBM Cloud
+        run: |
+          ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" -r "${IBM_CLOUD_REGION}" -g default
+          ibmcloud cr region-set "${IBM_CLOUD_REGION}"
+          ibmcloud cr login
+
       - name: 🛠 Build Docker Image
         run: |
           docker build -t "${REGISTRY_HOSTNAME}/${ICR_NAMESPACE}/${IMAGE_NAME}:${GITHUB_SHA}" .

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ref-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  rules:
+    - host: ref.yourdomain.com  # <-- Replace with your actual domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ref-service
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - ref.yourdomain.com
+      secretName: ref-tls-cert

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ref-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: ref
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5001


### PR DESCRIPTION
## Summary
- add IBM Cloud authentication to production workflow
- extract service and ingress manifests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ecae0b3248328a83a4052fb562a6a