### PR TITLE
Fix main module import and engine helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,23 @@
 from recursor import Recursor
-from test_tools import run_sareth_test  # type: ignore
+from sareth_test_mode import run_sareth_test  # type: ignore
 from visualizer import Visualizer
 from logger import StateLogger
-from recursor import Recursor
+
+def run_recursive_engine(*, depth: int = 10, threshold: float = 0.7):
+    """Run the Recursor with a simple numeric seed state."""
+    engine = Recursor(max_depth=depth, tension_threshold=threshold)
+
+    seed_state = [1.0, 1.5, 2.0]
+    final_state = engine.run(seed_state)
+
+    trace = engine.glyph_engine.trace()
+    glyph = trace[-1][1] if trace else ""
+
+    return final_state, glyph, "complete", engine
+
 
 if __name__ == "__main__":
-    state, glyph, reason = run_recursive_engine(depth=15, threshold=0.2)
+    state, glyph, reason, engine = run_recursive_engine(depth=15, threshold=0.2)
 
     # Visualize recursion
     vis = Visualizer(StateLogger())


### PR DESCRIPTION
## Summary
- use `sareth_test_mode` for `run_sareth_test`
- provide `run_recursive_engine` helper and update main

## Testing
- `pytest -q`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68768afc09c08328bf6d00c0d59b977e