### PR TITLE
Refactor entrypoints and streamline engine calls

### DIFF
--- a/engine_runner.py
+++ b/engine_runner.py
@@ -1,13 +1,16 @@
 # engine_runner.py
-from recursor import Recursor
+"""Thin wrapper for running the REF engine from the command line."""
 
-def run_recursive_engine(*, depth: int = 10, threshold: float = 0.7):
-    seed_state = [1.0, 2.0, 3.0]
-    engine = Recursor(max_depth=depth, tension_threshold=threshold)
-    final_state = engine.run(seed_state)
+from ref_engine import run_recursive_engine
 
-    glyph_trace = engine.glyph_engine.trace()
-    last_glyph = glyph_trace[-1][1] if glyph_trace else None
-    reason = "depth_limit" if len(glyph_trace) >= depth else "complete"
 
-    return final_state, last_glyph, reason
+def main(depth: int = 10, threshold: float = 0.7):
+    """Execute the recursive engine and print results."""
+    state, glyph, reason = run_recursive_engine(depth=depth, threshold=threshold)
+    print(f"Final State: {state}")
+    print(f"Last Glyph: {glyph}")
+    print(f"Halt Reason: {reason}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
+    main()

--- a/main.py
+++ b/main.py
@@ -1,23 +1,10 @@
-from recursor import Recursor
+"""Command line entrypoint and optional Streamlit UI for the REF engine."""
+
+from logger import StateLogger
 from test_tools import run_sareth_test
 from visualizer import Visualizer
-from logger import StateLogger
+from ref_engine import run_recursive_engine
 
-def run_recursive_engine(*, depth: int = 10, threshold: float = 0.7):
-    """Runs the recursive engine with user-defined parameters."""
-    seed_state = [1.0, 2.0, 3.0]
-    engine = Recursor(max_depth=depth, tension_threshold=threshold)
-    final_state = engine.run(seed_state)
-
-    glyph_trace = engine.glyph_engine.trace()
-    last_glyph = glyph_trace[-1][1] if glyph_trace else None
-
-    if len(glyph_trace) >= depth:
-        reason = "depth_limit"
-    else:
-        reason = "complete"
-
-    return final_state, last_glyph, reason
 
 # Optional Streamlit UI
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 pytest
 matplotlib
 nltk
+streamlit


### PR DESCRIPTION
## Summary
- centralize `run_recursive_engine` in `ref_engine` and import it in other entrypoints
- add a simple CLI in `engine_runner.py`
- update `main.py` to use the shared engine implementation
- include `streamlit` in requirements for full test coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687900ba5be483288ae7a12204dff98e