### PR TITLE
Fix Streamlit rerun deprecation

### DIFF
--- a/sareth_chat.py
+++ b/sareth_chat.py
@@ -137,4 +137,4 @@ if st.sidebar.button("Reset Conversation"):
         st.session_state.history.append(st.session_state.messages)
     st.session_state.messages = []
     st.session_state.glyph_trace = []
-    st.experimental_rerun()
+    st.rerun()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -118,7 +118,7 @@ def reset_conversation():
     st.session_state.user_input = ""
     st.session_state.search_query = ""
     st.success("Conversation reset!")
-    st.experimental_rerun()
+    st.rerun()
 
 def process_reflection():
     user_input = st.session_state.user_input.strip()
@@ -159,7 +159,7 @@ if not st.session_state.onboarded:
         st.markdown("1. Write a thought in the text box.\n2. Click **Reflect with Sareth**.\n3. Review the glyphs and insights that appear.")
         if st.button("Start Exploring", key="start_onboarding"):
             st.session_state.onboarded = True
-            st.experimental_rerun()
+            st.rerun()
 
 with st.expander("⚙️ Run REF Engine"):
     depth = st.slider("Max Recursion Depth", 1, 10, 5, key="depth", help="Number of recursion cycles to run")
@@ -195,7 +195,7 @@ with tab1:
         process_reflection()
     if submit_prompt:
         st.session_state.user_input = random.choice(reflection_prompts)
-        st.experimental_rerun()
+        st.rerun()
     if submit_reset:
         reset_conversation()
 


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun()` calls with `st.rerun()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd5a669108328bd576f8abdd274da