### PR TITLE
Add backend health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ npm install
 npm start
 ```
 
+Once running, you can perform a basic health check at `http://localhost:3001/health` which returns the backend version.
+
 Run the frontend with:
 
 ```bash

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const packageJson = require('./package.json');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
@@ -16,6 +17,10 @@ app.post('/process-recursion', (req, res) => {
   const { userId, input } = req.body;
   const insight = `Processed insight for ${userId}: ${input}`;
   res.status(200).send({ insight });
+});
+
+app.get('/health', (req, res) => {
+  res.status(200).send({ status: 'ok', version: packageJson.version });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add `/health` endpoint to backend API
- mention health check in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe70ec830832894c7eb54d3103f55