### PR TITLE
feat: add codex gating and signed commit enforcement

### DIFF
--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,8 @@
+"""Codex utilities for repository policy enforcement."""
+from .checks import verify_compliance, friction_alarm_passed, commit_signed
+
+__all__ = [
+    "verify_compliance",
+    "friction_alarm_passed",
+    "commit_signed",
+]

--- a/codex/checks.py
+++ b/codex/checks.py
@@ -1,0 +1,71 @@
+"""Policy checks for Codex rules enforcement."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+RULES_PATH = Path("codex/rules.json")
+MEMORY_PATH = Path("data/memory.jsonl")
+
+
+def load_rules(path: Path = RULES_PATH) -> dict[str, Any]:
+    """Load rule configuration from ``path``.
+
+    Returns an empty mapping if the file does not exist or is invalid.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def friction_alarm_passed(memory_file: Path | str = MEMORY_PATH, *, last_n: int = 10) -> bool:
+    """Return ``True`` if a passing friction alarm exists in the last ``last_n`` entries."""
+    path = Path(memory_file)
+    if not path.exists():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()[-last_n:]
+    except OSError:
+        return False
+    for line in reversed(lines):
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("event") == "friction_alarm" and entry.get("status") == "pass":
+            return True
+    return False
+
+
+def commit_signed() -> bool:
+    """Return ``True`` if the latest commit is signed with a trusted signature.
+
+    Uses ``git log -1 --pretty=%G?`` where ``G`` indicates a good signature and
+    ``R`` indicates a good, trusted signature.
+    """
+    try:
+        status = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%G?"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return status in {"G", "R"}
+
+
+def verify_compliance() -> bool:
+    """Verify all enabled Codex rules.
+
+    Returns ``True`` when all checks pass, otherwise ``False``.
+    """
+    rules = load_rules()
+    if rules.get("require_friction_alarm"):
+        if not friction_alarm_passed():
+            return False
+    if rules.get("enforce_signed_commits"):
+        if not commit_signed():
+            return False
+    return True

--- a/codex/rules.json
+++ b/codex/rules.json
@@ -1,0 +1,4 @@
+{
+  "require_friction_alarm": false,
+  "enforce_signed_commits": false
+}

--- a/data/memory.jsonl
+++ b/data/memory.jsonl
@@ -1,0 +1,1 @@
+{"event": "friction_alarm", "status": "pass", "detail": "initial entry"}

--- a/tests/test_codex_checks.py
+++ b/tests/test_codex_checks.py
@@ -1,0 +1,45 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from codex import checks
+
+
+def _write_entries(entries, path: Path):
+    with path.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def test_friction_alarm_passed():
+    with tempfile.TemporaryDirectory() as tmp:
+        mem = Path(tmp) / "memory.jsonl"
+        entries = [{"event": "other"}] * 9 + [{"event": "friction_alarm", "status": "pass"}]
+        _write_entries(entries, mem)
+        assert checks.friction_alarm_passed(mem)
+
+        entries = [{"event": "other"}] * 10
+        _write_entries(entries, mem)
+        assert not checks.friction_alarm_passed(mem)
+
+
+@mock.patch("subprocess.check_output")
+def test_commit_signed(mock_co):
+    mock_co.return_value = "G"
+    assert checks.commit_signed()
+    mock_co.return_value = "R"
+    assert checks.commit_signed()
+    mock_co.return_value = "N"
+    assert not checks.commit_signed()
+
+
+@mock.patch("codex.checks.commit_signed", return_value=True)
+def test_verify_compliance(mock_signed):
+    with tempfile.TemporaryDirectory() as tmp:
+        mem = Path(tmp) / "memory.jsonl"
+        _write_entries([{"event": "friction_alarm", "status": "pass"}], mem)
+        rules = {"require_friction_alarm": True, "enforce_signed_commits": True}
+        with mock.patch("codex.checks.load_rules", return_value=rules), \
+             mock.patch("codex.checks.MEMORY_PATH", mem):
+            assert checks.verify_compliance()


### PR DESCRIPTION
## Summary
- add Codex policy checks for friction alarm gating and signed commit enforcement
- introduce default rules configuration and sample memory log
- test friction alarm and commit signature rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6837df08328bcd0e504a6b138b4