### PR TITLE
Integrate ChatGPT in backend recursion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npm start
 
 Once running, you can perform a basic health check at `http://localhost:3001/health` which returns the backend version.
 
+The `/process-recursion` endpoint uses OpenAI's ChatGPT to turn user input into reflective insights. Set an `OPENAI_API_KEY` environment variable before starting the server to enable this behavior.
+
 Run the frontend with:
 
 ```bash

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "server.js",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "openai": "^4.104.0"
   },
   "scripts": {
     "start": "node server.js"

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,11 @@
 const express = require('express');
+const OpenAI = require('openai');
 const packageJson = require('./package.json');
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// Configure OpenAI client using the environment API key
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 app.use(express.json());
 
@@ -13,10 +17,22 @@ app.post('/save-onboarding', (req, res) => {
   res.status(200).send({ message: 'Onboarding responses saved successfully.' });
 });
 
-app.post('/process-recursion', (req, res) => {
+app.post('/process-recursion', async (req, res) => {
   const { userId, input } = req.body;
-  const insight = `Processed insight for ${userId}: ${input}`;
-  res.status(200).send({ insight });
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are Sareth, a recursive guide helping users reflect.' },
+        { role: 'user', content: input },
+      ],
+    });
+    const insight = completion.choices[0].message.content;
+    res.status(200).send({ insight });
+  } catch (err) {
+    console.error('OpenAI request failed', err);
+    res.status(500).send({ error: 'Failed to generate insight.' });
+  }
 });
 
 app.get('/health', (req, res) => {


### PR DESCRIPTION
## Summary
- hook `/process-recursion` into OpenAI to return reflective insights
- document new ChatGPT integration and API key requirement

## Testing
- `pytest`
- `OPENAI_API_KEY=fake node backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a623e75010832884ec8c6de855ed1c