### PR TITLE
Use OpenAI API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Trigger deployment: Added test commit to README
 ## 🌐 Frontend & Backend
 The `frontend` directory contains a React implementation of the REF onboarding screens and interaction hub. The `backend` directory exposes an Express API for saving onboarding responses and performing simple recursion processing.
 
+### OpenAI API key
+
+Both the backend and any local Python helpers require an OpenAI API key. Set it in your environment before running components:
+
+```bash
+export OPENAI_API_KEY="your-secret-key"
+```
+
 Run the backend with:
 
 ```bash

--- a/ai/serif_agent.py
+++ b/ai/serif_agent.py
@@ -1,6 +1,10 @@
 import openai
+import os
 
-openai.api_key = 'YOUR_OPENAI_API_KEY'
+# Configure OpenAI with a secret key from the environment
+openai.api_key = os.getenv("OPENAI_API_KEY")
+if openai.api_key is None:
+    raise ValueError("OPENAI_API_KEY environment variable is not set")
 
 def serif_prompt(user_input, conversation_context):
     prompt = f"""

--- a/client/src/components/server/app.py
+++ b/client/src/components/server/app.py
@@ -4,6 +4,8 @@ import os
 
 app = Flask(__name__)
 openai.api_key = os.getenv("OPENAI_API_KEY")
+if openai.api_key is None:
+    raise ValueError("OPENAI_API_KEY environment variable is not set")
 
 @app.route('/process', methods=['POST'])
 def process():


### PR DESCRIPTION
## Summary
- Load OpenAI API key from `OPENAI_API_KEY` environment variable in local agents and Flask server.
- Document required API key in README to move beyond demo mode.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc613e839883288b752694f5bcb0e6