### PR TITLE
Fix Streamlit app on Main: resolve merge conflict, wire OpenAI secrets, and ensure deploy picks up changes

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -1,0 +1,2 @@
+OPENAI_API_KEY = "sk-your-real-key-here"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-openai
+openai>=1.0.0
 numpy
 transformers
 requests
 pytest
 matplotlib
 nltk
-streamlit
+streamlit>=1.36.0


### PR DESCRIPTION
## Summary
- replace Streamlit entrypoint with minimal chat app using OpenAI v1 streaming and commit banner
- pin openai and streamlit dependencies and add example secrets file
- clarify example OpenAI key placeholder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc68ec6028832892bbac9659269aed