### PR TITLE
Handle optional python-dotenv import

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,7 +2,13 @@ import os
 from typing import List, Dict
 
 import streamlit as st
-from dotenv import load_dotenv
+try:  # pragma: no cover - graceful optional dependency
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # If python-dotenv isn't installed, provide a no-op
+    def load_dotenv(*args, **kwargs):  # type: ignore
+        """Fallback loader when python-dotenv is unavailable."""
+        return False
+
 from openai import OpenAI, OpenAIError
 
 # -----------------------------


### PR DESCRIPTION
## Summary
- Gracefully handle missing python-dotenv in `streamlit_app.py`
- Provide no-op fallback so app runs without dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be43a1e0948328add0bc3ae0ac6866