### PR TITLE
feat(rve): add Reality Verification Engine page + Postgres-backed ledger

### DIFF
--- a/pages/Reality_Verification_Engine.py
+++ b/pages/Reality_Verification_Engine.py
@@ -1,0 +1,75 @@
+import streamlit as st
+import matplotlib.pyplot as plt
+
+from rve.ledger import get_session, add_claim, append_drift, Claim
+
+
+st.set_page_config(page_title="Reality Verification Engine", layout="wide")
+
+
+def drift_chart(history):
+    xs = list(range(len(history)))
+    ys = [h.drift for h in history]
+    fig, ax = plt.subplots()
+    ax.plot(xs, ys, marker="o")
+    ax.set_xlabel("Checkpoint")
+    ax.set_ylabel("Drift")
+    ax.set_title("Drift Over Time")
+    st.pyplot(fig)
+
+
+def page():
+    st.markdown("# Reality Verification Engine")
+    st.caption(
+        "REF-integrated page to verify claims, track provenance, and visualize drift."
+    )
+
+    sess = get_session()
+
+    st.subheader("New Claim")
+    with st.form("new_claim"):
+        text = st.text_input("Falsifiable claim (1 sentence)", "")
+        volatility = st.selectbox("Volatility tag", ["stable", "seasonal", "breaking"])
+        cols = st.columns(3)
+        a = cols[0].checkbox("Raw artifact attached")
+        b = cols[0].checkbox("Method documented")
+        c = cols[1].checkbox("Timestamp/source recorded")
+        d = cols[1].checkbox("Hash/immutability recorded")
+        e = cols[2].checkbox("Chain-of-custody listed")
+        f = cols[2].checkbox("Reproducible steps written")
+        indep = st.slider("Independent confirmations", 0, 3, 1)
+        if st.form_submit_button("Create Claim") and text.strip():
+            prov_fields = sum([a, b, c, d, e, f])
+            claim = add_claim(sess, text.strip(), volatility, prov_fields, 6, indep)
+            st.success(f"Created {claim.claim_id}")
+
+    st.subheader("Active Claims")
+    claims = sess.query(Claim).order_by(Claim.created_at.desc()).all()
+    if not claims:
+        st.info("No claims yet.")
+    for c in claims:
+        st.markdown(f"### {c.claim_id}")
+        col1, col2, col3, col4 = st.columns(4)
+        col1.metric("Confidence", f"{int(c.confidence_index * 100)}%")
+        col2.metric("Drift", f"{c.drift_score:.1f}")
+        col3.metric("Provenance", f"{int(c.provenance_completeness * 100)}%")
+        col4.metric("Independence", f"{c.independence_score} / 3")
+        with st.expander("Drift Over Time"):
+            drift_chart(c.histories)
+            new_val = st.slider(
+                f"Update drift for {c.claim_id}",
+                0.0,
+                5.0,
+                float(c.drift_score),
+                0.1,
+                key=f"dr_{c.id}",
+            )
+            if st.button(f"Add checkpoint for {c.claim_id}", key=f"btn_{c.id}"):
+                append_drift(sess, c, new_val)
+                st.experimental_rerun()
+        st.divider()
+
+
+if __name__ == "__main__":
+    page()
+

--- a/ref-backend/rve_api.py
+++ b/ref-backend/rve_api.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from rve.ledger import Claim, get_session
+
+
+app = FastAPI(title="RVE API")
+
+
+class ClaimOut(BaseModel):
+    claim_id: str
+    text: str
+    drift_score: float
+    confidence_index: float
+    provenance_completeness: float
+    independence_score: int
+    created_at: str
+    volatility: str
+
+
+@app.get("/claims", response_model=list[ClaimOut])
+def list_claims():
+    sess = get_session()
+    rows = sess.query(Claim).order_by(Claim.created_at.desc()).all()
+    return [
+        ClaimOut(
+            claim_id=r.claim_id,
+            text=r.text,
+            drift_score=r.drift_score,
+            confidence_index=r.confidence_index,
+            provenance_completeness=r.provenance_completeness,
+            independence_score=r.independence_score,
+            created_at=r.created_at.isoformat(),
+            volatility=r.volatility,
+        )
+        for r in rows
+    ]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,13 @@ numpy
 transformers
 requests
 pytest
-matplotlib
+matplotlib>=3.8
 nltk
 streamlit>=1.36.0
+sqlalchemy>=2.0
+psycopg2-binary>=2.9
+python-dotenv>=1.0
+alembic>=1.13
+pendulum>=3.0
+fastapi>=0.111
+uvicorn>=0.30

--- a/rve/__init__.py
+++ b/rve/__init__.py
@@ -1,0 +1,3 @@
+from .ledger import *
+from .config import *
+

--- a/rve/config.py
+++ b/rve/config.py
@@ -1,0 +1,16 @@
+import os
+
+
+def get_db_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    data_dir = os.getenv("RVE_DATA_DIR", ".")
+    os.makedirs(data_dir, exist_ok=True)
+    return f"sqlite:///{os.path.join(data_dir, 'rve_ledger.db')}"
+
+
+def env_bool(name: str, default=False) -> bool:
+    val = os.getenv(name, str(default)).lower()
+    return val in ("1", "true", "yes", "on")
+

--- a/rve/ledger.py
+++ b/rve/ledger.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+from .config import get_db_url
+
+
+Base = declarative_base()
+
+
+class Claim(Base):
+    __tablename__ = "claims"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    claim_id = Column(String(32), unique=True, index=True)
+    text = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    volatility = Column(String(16), default="stable", index=True)
+    provenance_completeness = Column(Float, default=0.0)
+    independence_score = Column(Integer, default=0)
+    drift_score = Column(Float, default=0.0, index=True)
+    confidence_index = Column(Float, default=0.0, index=True)
+    meta = Column(Text, default="{}")
+    histories = relationship(
+        "DriftHistory", back_populates="claim", cascade="all, delete-orphan"
+    )
+    artifacts = relationship(
+        "Artifact", back_populates="claim", cascade="all, delete-orphan"
+    )
+
+
+Index("idx_claims_scores", Claim.drift_score, Claim.confidence_index)
+
+
+class DriftHistory(Base):
+    __tablename__ = "drift_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    claim_id_fk = Column(Integer, ForeignKey("claims.id"), index=True)
+    t = Column(DateTime, default=datetime.utcnow, index=True)
+    drift = Column(Float, nullable=False)
+    claim = relationship("Claim", back_populates="histories")
+
+
+class Artifact(Base):
+    __tablename__ = "artifacts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    claim_id_fk = Column(Integer, ForeignKey("claims.id"), index=True)
+    kind = Column(String(32))
+    path_or_url = Column(Text, nullable=False)
+    hash = Column(String(128))
+    has_method_doc = Column(Boolean, default=False)
+    has_timestamp = Column(Boolean, default=False)
+    has_chain = Column(Boolean, default=False)
+    is_reproducible = Column(Boolean, default=False)
+    claim = relationship("Claim", back_populates="artifacts")
+
+
+def get_engine():
+    return create_engine(get_db_url(), future=True)
+
+
+def get_session():
+    engine = get_engine()
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def next_claim_human_id(sess) -> str:
+    count = sess.query(Claim).count() + 1
+    return f"CLM-{count:04d}"
+
+
+def add_claim(
+    sess,
+    text: str,
+    volatility: str = "stable",
+    prov_fields: int = 0,
+    prov_total: int = 6,
+    independent_sources: int = 1,
+):
+    pc = prov_fields / float(max(prov_total, 1))
+    ind = max(0, min(3, independent_sources))
+    drift = max(0.0, min(5.0, 3.0 - (pc * 2.0) - (0.4 * ind)))
+    conf = max(
+        0.0,
+        min(1.0, (0.6 * pc + 0.4 * (ind / 3.0)) * (1.0 - (drift / 10.0))),
+    )
+    claim = Claim(
+        claim_id=next_claim_human_id(sess),
+        text=text,
+        volatility=volatility,
+        provenance_completeness=pc,
+        independence_score=ind,
+        drift_score=drift,
+        confidence_index=conf,
+        meta="{}",
+    )
+    sess.add(claim)
+    sess.flush()
+    sess.add(DriftHistory(claim_id_fk=claim.id, drift=drift))
+    sess.commit()
+    return claim
+
+
+def append_drift(sess, claim: Claim, drift_value: float):
+    claim.drift_score = float(drift_value)
+    sess.add(DriftHistory(claim_id_fk=claim.id, drift=float(drift_value)))
+    sess.commit()
+    return claim
+


### PR DESCRIPTION
## Summary
- implement RVE package with SQLAlchemy models for claims, drift history and artifacts
- add Streamlit multipage UI to create and manage claims with drift chart
- expose optional FastAPI endpoint to list claims
- update requirements for database, API, and supporting libs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0767941008328900d872b53aa132d