### PR TITLE
Add DB-backed authentication and scoped RVE ledger

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,34 @@
+[alembic]
+script_location = alembic
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,40 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from rve.ledger import Base, get_engine
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = str(get_engine().url)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = get_engine()
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_add_user_scope.py
+++ b/alembic/versions/0001_add_user_scope.py
@@ -1,0 +1,68 @@
+"""add users table and user_id columns"""
+
+
+from alembic import op
+import sqlalchemy as sa
+from werkzeug.security import generate_password_hash
+from datetime import datetime
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.add_column("claims", sa.Column("user_id", sa.Integer(), nullable=True))
+    op.create_index("ix_claims_user_id", "claims", ["user_id"])
+    op.create_foreign_key(None, "claims", "users", ["user_id"], ["id"])
+
+    op.add_column("drift_history", sa.Column("user_id", sa.Integer(), nullable=True))
+    op.create_index("ix_drift_history_user_id", "drift_history", ["user_id"])
+    op.create_foreign_key(None, "drift_history", "users", ["user_id"], ["id"])
+
+    op.add_column("artifacts", sa.Column("user_id", sa.Integer(), nullable=True))
+    op.create_index("ix_artifacts_user_id", "artifacts", ["user_id"])
+    op.create_foreign_key(None, "artifacts", "users", ["user_id"], ["id"])
+
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "INSERT INTO users (email, password_hash, created_at) VALUES (:email, :pw, :created_at)"
+        ),
+        {
+            "email": "public-demo@rve.local",
+            "pw": generate_password_hash("demo"),
+            "created_at": datetime.utcnow(),
+        },
+    )
+    demo_id = result.inserted_primary_key[0]
+    for table in ("claims", "drift_history", "artifacts"):
+        conn.execute(sa.text(f"UPDATE {table} SET user_id = :uid"), {"uid": demo_id})
+    op.alter_column("claims", "user_id", nullable=False)
+    op.alter_column("drift_history", "user_id", nullable=False)
+    op.alter_column("artifacts", "user_id", nullable=False)
+
+
+def downgrade():
+    op.drop_constraint(None, "artifacts", type_="foreignkey")
+    op.drop_constraint(None, "drift_history", type_="foreignkey")
+    op.drop_constraint(None, "claims", type_="foreignkey")
+    op.drop_index("ix_artifacts_user_id", table_name="artifacts")
+    op.drop_index("ix_drift_history_user_id", table_name="drift_history")
+    op.drop_index("ix_claims_user_id", table_name="claims")
+    op.drop_column("artifacts", "user_id")
+    op.drop_column("drift_history", "user_id")
+    op.drop_column("claims", "user_id")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/pages/Reality_Verification_Engine.py
+++ b/pages/Reality_Verification_Engine.py
@@ -2,10 +2,20 @@ import streamlit as st
 import matplotlib.pyplot as plt
 
 from rve.ledger import get_session, add_claim, append_drift, Claim, User
-from ._auth import auth_gate, get_current_user
-
+from rve.auth import auth_gate, get_current_user
 
 st.set_page_config(page_title="Reality Verification Engine", layout="wide")
+
+sess = get_session()
+user = get_current_user(sess)
+if not user:
+    auth_gate()
+    st.stop()
+
+st.markdown("# Reality Verification Engine")
+st.caption(
+    "Check if a claim stays aligned with reality. See how much the story changed, how strong the evidence is, and how confident you can be."
+)
 
 LABELS = {
     "drift": "Story change",
@@ -15,9 +25,9 @@ LABELS = {
 }
 TOOLTIPS = {
     "drift": "How much the story has shifted from its original evidence (lower is better).",
-    "provenance": "How well this claim is backed by timestamps, methods, and artifacts.",
-    "confidence": "Overall how solid this looks, given evidence and story change.",
-    "independence": "How many independent confirmations support this.",
+    "provenance": "How well this claim is backed (timestamps, methods, artifacts).",
+    "confidence": "Overall solidity, given evidence and story change.",
+    "independence": "How many independent confirmations you have.",
 }
 
 
@@ -33,119 +43,86 @@ def drift_chart(history):
 
 
 def explain_interpretation(claim):
-    steps = []
     pc = claim.provenance_completeness
     ind = claim.independence_score
     drift = claim.drift_score
     conf = claim.confidence_index
-
-    steps.append(
-        f"Evidence strength (provenance completeness) = {int(pc*100)}% from checklist items filled / total."
-    )
-    steps.append(f"Unique sources = {ind} out of 3.")
-    steps.append(
-        "Story change (drift): baseline 3.0, minus 2.0×evidence, minus 0.4×sources, clamped to [0,5]."
-    )
-    steps.append(f"→ Drift = {drift:.2f}")
-    steps.append(
-        "Confidence: 60% weight on evidence + 40% on sources, attenuated by drift/10."
-    )
-    steps.append(f"→ Confidence = {int(conf*100)}%")
-
-    integrity = []
-    integrity.append("• Timestamp present?" + (" ✅" if pc >= 0.17 else " ⚠️"))
-    integrity.append("• Method documented?" + (" ✅" if pc >= 0.34 else " ⚠️"))
-    integrity.append("• Hash/immutability?" + (" ✅" if pc >= 0.50 else " ⚠️"))
-    integrity.append("• Chain-of-custody listed?" + (" ✅" if pc >= 0.67 else " ⚠️"))
-    integrity.append("• Reproducible steps?" + (" ✅" if pc >= 0.84 else " ⚠️"))
-
-    return steps, integrity
+    steps = [
+        f"Evidence strength = {int(pc*100)}% (filled provenance items / total).",
+        f"Unique sources = {ind} / 3.",
+        "Story change (drift) = 3.0 - 2.0×evidence - 0.4×sources, clamped to [0,5].",
+        f"→ Drift = {drift:.2f}",
+        "Confidence = 0.6×evidence + 0.4×(sources/3), attenuated by drift/10.",
+        f"→ Confidence = {int(conf*100)}%",
+    ]
+    checks = [
+        "• Timestamp present? " + ("✅" if pc >= 0.17 else "⚠️"),
+        "• Method documented? " + ("✅" if pc >= 0.34 else "⚠️"),
+        "• Hash/immutability? " + ("✅" if pc >= 0.50 else "⚠️"),
+        "• Chain-of-custody? " + ("✅" if pc >= 0.67 else "⚠️"),
+        "• Reproducible steps? " + ("✅" if pc >= 0.84 else "⚠️"),
+    ]
+    return steps, checks
 
 
-def page():
-    st.markdown("# Reality Verification Engine")
-    st.caption(
-        "Check if a claim stays aligned with reality. RVE shows how much the story changed, how strong the evidence is, and how confident you can be."
-    )
+with st.expander("See an example first (recommended)"):
+    st.write("**Example claim:** “Ocean temperatures are rising.”")
+    st.write("Story change: **1.1 (low)**, Evidence strength: **80%**, Unique sources: **3/3**, Confidence: **92%**.")
+    st.write("Why: multiple independent datasets with timestamps & methods align within expected variance.")
 
-    st.markdown("## What RVE does for you")
-    st.write("RVE helps you check whether a claim stays aligned with reality. It shows:")
-    st.write("• Story change — how much the story has shifted from its original evidence.")
-    st.write("• Evidence strength — how well the claim is backed up (timestamps, methods, artifacts).")
-    st.write("• Unique sources — how many independent confirmations you have.")
-    st.write("• Confidence — how solid this looks overall.")
+st.subheader("New Claim")
+with st.form("new_claim"):
+    text = st.text_input("Falsifiable claim (1 sentence)", "")
+    volatility = st.selectbox("Volatility tag", ["stable", "seasonal", "breaking"])
+    cols = st.columns(3)
+    a = cols[0].checkbox("Raw artifact attached")
+    b = cols[0].checkbox("Method documented")
+    c = cols[1].checkbox("Timestamp/source recorded")
+    d = cols[1].checkbox("Hash/immutability recorded")
+    e = cols[2].checkbox("Chain-of-custody listed")
+    f = cols[2].checkbox("Reproducible steps written")
+    indep = st.slider("Independent confirmations", 0, 3, 1)
+    if st.form_submit_button("Create Claim") and text.strip():
+        prov_fields = sum([a, b, c, d, e, f])
+        claim = add_claim(sess, user, text.strip(), volatility, prov_fields, 6, indep)
+        st.success(f"Created {claim.claim_id}")
 
-    user_email = get_current_user()
-    if not user_email:
-        auth_gate()
-        st.stop()
-
-    with st.expander("See an example first (recommended)"):
-        st.write("**Example claim:** “Ocean temperatures are rising.”")
-        st.write("Story change: **1.1 (low)**, Evidence strength: **80%**, Unique sources: **3/3**, Confidence: **92%**.")
-        st.write("Why: multiple independent datasets with timestamps & methods align within expected variance.")
-
-    sess = get_session()
-    user = sess.query(User).filter_by(email=user_email).one()
-
-    st.subheader("New Claim")
-    with st.form("new_claim"):
-        text = st.text_input("Falsifiable claim (1 sentence)", "")
-        volatility = st.selectbox("Volatility tag", ["stable", "seasonal", "breaking"])
-        cols = st.columns(3)
-        a = cols[0].checkbox("Raw artifact attached")
-        b = cols[0].checkbox("Method documented")
-        c = cols[1].checkbox("Timestamp/source recorded")
-        d = cols[1].checkbox("Hash/immutability recorded")
-        e = cols[2].checkbox("Chain-of-custody listed")
-        f = cols[2].checkbox("Reproducible steps written")
-        indep = st.slider("Independent confirmations", 0, 3, 1)
-        if st.form_submit_button("Create Claim") and text.strip():
-            prov_fields = sum([a, b, c, d, e, f])
-            claim = add_claim(sess, user, text.strip(), volatility, prov_fields, 6, indep)
-            st.success(f"Created {claim.claim_id}")
-
-    st.subheader("Active Claims")
-    claims = (
-        sess.query(Claim)
-        .filter(Claim.user_id == user.id)
-        .order_by(Claim.created_at.desc())
-        .all()
-    )
-    if not claims:
-        st.info("No claims yet.")
-    for c in claims:
-        st.markdown(f"### {c.claim_id}")
-        col1, col2, col3, col4 = st.columns(4)
-        col1.metric(LABELS["confidence"], f"{int(c.confidence_index * 100)}%", help=TOOLTIPS["confidence"])
-        col2.metric(LABELS["drift"], f"{c.drift_score:.1f}", help=TOOLTIPS["drift"])
-        col3.metric(LABELS["provenance"], f"{int(c.provenance_completeness * 100)}%", help=TOOLTIPS["provenance"])
-        col4.metric(LABELS["independence"], f"{c.independence_score} / 3", help=TOOLTIPS["independence"])
-        with st.expander("Drift Over Time"):
-            drift_chart(c.histories)
-            new_val = st.slider(
-                f"Update drift for {c.claim_id}",
-                0.0,
-                5.0,
-                float(c.drift_score),
-                0.1,
-                key=f"dr_{c.id}",
-            )
-            if st.button(f"Add checkpoint for {c.claim_id}", key=f"btn_{c.id}"):
-                append_drift(sess, user, c, new_val)
-                st.experimental_rerun()
-        with st.expander("How we interpreted this"):
-            steps, integrity = explain_interpretation(c)
-            st.markdown("**Calculation path**")
-            for s in steps:
-                st.write("- " + s)
-            st.markdown("**Integrity checks**")
-            for ic in integrity:
-                st.write(ic)
-            st.caption("These are transparent, deterministic calculations; no hidden model reasoning.")
-        st.divider()
-
-
-if __name__ == "__main__":
-    page()
-
+st.subheader("Active Claims")
+claims = (
+    sess.query(Claim)
+    .filter(Claim.user_id == user.id)
+    .order_by(Claim.created_at.desc())
+    .all()
+)
+if not claims:
+    st.info("No claims yet.")
+for c in claims:
+    st.markdown(f"### {c.claim_id}")
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric(LABELS["confidence"], f"{int(c.confidence_index * 100)}%", help=TOOLTIPS["confidence"])
+    col2.metric(LABELS["drift"], f"{c.drift_score:.1f}", help=TOOLTIPS["drift"])
+    col3.metric(LABELS["provenance"], f"{int(c.provenance_completeness * 100)}%", help=TOOLTIPS["provenance"])
+    col4.metric(LABELS["independence"], f"{c.independence_score} / 3", help=TOOLTIPS["independence"])
+    with st.expander("Drift Over Time"):
+        drift_chart(c.histories)
+        new_val = st.slider(
+            f"Update drift for {c.claim_id}",
+            0.0,
+            5.0,
+            float(c.drift_score),
+            0.1,
+            key=f"dr_{c.id}",
+        )
+        if st.button(f"Add checkpoint for {c.claim_id}", key=f"btn_{c.id}"):
+            append_drift(sess, user, c, new_val)
+            st.experimental_rerun()
+    with st.expander("How we interpreted this"):
+        steps, checks = explain_interpretation(c)
+        st.markdown("**Calculation path**")
+        for s in steps:
+            st.write("- " + s)
+        st.markdown("**Integrity checks**")
+        for ch in checks:
+            st.write(ch)
+        st.caption("Deterministic calculations shown transparently; no hidden model reasoning.")
+    st.divider()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ alembic>=1.13
 pendulum>=3.0
 fastapi>=0.111
 uvicorn>=0.30
-werkzeug>=2.0
+werkzeug>=3.0

--- a/rve/auth.py
+++ b/rve/auth.py
@@ -2,19 +2,21 @@ import streamlit as st
 from rve.ledger import get_session, get_or_create_user, User
 
 
-def get_current_user():
-    if "user_email" in st.session_state:
-        return st.session_state["user_email"]
-    return None
+def get_current_user(sess=None) -> User | None:
+    uid = st.session_state.get("user_id")
+    if not uid:
+        return None
+    sess = sess or get_session()
+    return sess.query(User).get(uid)
 
 
 def auth_gate():
     st.markdown("### Sign in")
     email = st.text_input("Email")
     pw = st.text_input("Password", type="password")
-    if st.button("Sign in / Create account"):
+    if st.button("Sign in / Create account") and email and pw:
         sess = get_session()
-        u = get_or_create_user(sess, email, pw)
+        u = get_or_create_user(sess, email.strip(), pw)
         st.session_state["user_email"] = u.email
         st.session_state["user_id"] = u.id
         st.experimental_rerun()


### PR DESCRIPTION
## Summary
- add `werkzeug>=3.0` dependency and move Streamlit auth logic into `rve.auth`
- gate Reality Verification Engine page with sign-in, add human-friendly labels and interpretation panel, and scope queries to the signed-in user
- introduce Alembic migration adding `users` table plus `user_id` foreign keys for claims, drift history, and artifacts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c087aee0148328859a33d3fac836dd